### PR TITLE
Add "secondary" and "ambivalent" spam folders

### DIFF
--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -20,6 +20,17 @@ $config['markasjunk2_ham_mbox'] = null;
 // set to FALSE to disable message moving
 $config['markasjunk2_spam_mbox'] = null;
 
+// Secondary Spam mailboxes
+// If there are other systems (like spamassassin) that move spam around,
+// set additional mbox(es) here to treat as spam folder.
+$config['markasjunk2_secondary_spam_mbox'] = null;
+
+// Suspicious mail mailbox
+// If there are other systems (like spamassassin) that move spam around,
+// set additional mbox(es) here to treat as "suspicious" folder -
+// both "mark as spam" and "mark as not spam" buttons will be shown
+$config['markasjunk2_suspicious_mbox'] = null;
+
 // Mark messages as read when reporting them as spam
 $config['markasjunk2_read_spam'] = true;
 

--- a/markasjunk2.js
+++ b/markasjunk2.js
@@ -112,11 +112,11 @@ function rcmail_markasjunk2_update() {
 		hamobj = hamobj.parent();
 	}
 
-	if (rcmail.env.markasjunk2_override || rcmail.is_multifolder_listing()) {
+	if (rcmail.env.markasjunk2_override || rcmail.is_multifolder_listing() || (rcmail.env.markasjunk2_suspicious_mailbox && rcmail.env.markasjunk2_suspicious_mailbox.indexOf(rcmail.env.mailbox) >= 0) ) {
 		spamobj.show();
 		hamobj.show();
 	}
-	else if (rcmail.env.markasjunk2_spam_mailbox && rcmail.env.mailbox != rcmail.env.markasjunk2_spam_mailbox) {
+	else if (rcmail.env.markasjunk2_spam_mailbox && rcmail.env.mailbox != rcmail.env.markasjunk2_spam_mailbox && (!rcmail.env.markasjunk2_secondary_spam_mailbox || rcmail.env.markasjunk2_secondary_spam_mailbox.indexOf(rcmail.env.mailbox) == -1)) {
 		spamobj.show();
 		hamobj.hide();
 	}


### PR DESCRIPTION
Hi @JohnDoh! I'm currently upgrading my organization's roundcube setup and I'm going to use your plugin. Since we have a system set up with spamassassin and sieve that can move spam into different folders according to SA's spam score, I've extended the button showing logic a little. The gist of the explanation is in the `config.inc.php.dist` comments. I hope you find it interesting enough to include!

Maybe a note should be made that the new config values must be arrays, or I could fix the code to work with both strings and arrays - what do you think would be best?
And sorry if anything looks weird - I'm not a fulltime PHP or JS dev. I'll be happy to fix anything that could be done in a more idiomatic way.

PR description:

For automated systems that move spam around (like a spamassassin + sieve
setup), there may be several folders that are for spam. For example, a
folder for spam classified by spamassassin with high confidence, one for
low confidence, and one for mails marked / moved by the user's mail
client (like the adaptive spam filter in thunderbird).

This PR adds config options to configure these folders and updates
the hide/unhide logic for the mark as spam / mark as not spam buttons
accordingly: Mailboxes configured as "secondary" spam folders show the "Not Junk" button,
while "suspicious" folders show both buttons.